### PR TITLE
Rebrand marketing to Webara Forge, add Forge pages and layout updates

### DIFF
--- a/src/app/(marketing)/about/page.tsx
+++ b/src/app/(marketing)/about/page.tsx
@@ -1,0 +1,27 @@
+import { ForgePage } from '@/components/sections/forge-page';
+
+export default function AboutPage() {
+  return (
+    <ForgePage
+      eyebrow="About"
+      title="A selective venture platform built in Tema."
+      intro="Webara Forge exists to compress years of learning into a focused 14-week operating environment for high-agency builders."
+      sections={[
+        {
+          heading: 'What Webara Forge is',
+          body: 'A hacker house and venture studio designed for serious teams that can build fast, validate rigorously, and execute with discipline.',
+        },
+        {
+          heading: 'Why Tema, why Ghana',
+          body: 'The Forge is grounded in local realities and national opportunity, while holding itself to global standards for speed and quality.',
+        },
+        {
+          heading: 'Operating philosophy',
+          body: 'Pressure creates signal. Teams are expected to ship, test assumptions, and make hard decisions based on evidence.',
+          bullets: ['Build with urgency', 'Validate with users', 'Keep or kill based on signal'],
+        },
+      ]}
+      ctas={[{ href: '/apply', label: 'Apply' }, { href: '/how-it-works', label: 'See the 14-week model', variant: 'outline' }]}
+    />
+  );
+}

--- a/src/app/(marketing)/apply/page.tsx
+++ b/src/app/(marketing)/apply/page.tsx
@@ -1,0 +1,17 @@
+import { ForgePage } from '@/components/sections/forge-page';
+
+export default function ApplyPage() {
+  return (
+    <ForgePage
+      eyebrow="Apply"
+      title="For serious builders only."
+      intro="Webara Forge is selective by design. The process screens for commitment, execution speed, and ability to operate under pressure."
+      sections={[
+        { heading: 'Who should apply', body: 'Ambitious product, engineering, and commercial operators who want to build companies in a high-accountability environment.' },
+        { heading: 'What is provided', body: 'A live-in operating environment with structured build cycles, mentorship access, and a focused peer group.' },
+        { heading: 'Selection process', body: 'Application review, interviews, and practical assessment before cohort placement.' },
+      ]}
+      ctas={[{ href: '/contact', label: 'Start application' }]}
+    />
+  );
+}

--- a/src/app/(marketing)/cohorts/[slug]/page.tsx
+++ b/src/app/(marketing)/cohorts/[slug]/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+
+export default async function CohortDetailPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+
+  return (
+    <div className="container mx-auto max-w-7xl space-y-8 px-4 py-14 md:px-6 md:py-20">
+      <h1 className="text-4xl font-semibold tracking-tight">{slug.replaceAll('-', ' ')}</h1>
+      <p className="max-w-3xl text-muted-foreground">
+        Cohort detail pages are designed as the long-term proof-of-work archive for team output, member participation, demos, and outcomes.
+      </p>
+      <div className="grid gap-4 md:grid-cols-3">
+        {['Teams', 'Members', 'Projects'].map((label) => (
+          <article key={label} className="rounded-lg border border-border bg-card p-6">
+            <h2 className="text-lg font-semibold">{label}</h2>
+            <p className="mt-2 text-sm text-muted-foreground">Structured relationships from CMS content will populate this section.</p>
+          </article>
+        ))}
+      </div>
+      <Link href="/apply" className="text-sm font-semibold text-primary">Apply for the next cohort →</Link>
+    </div>
+  );
+}

--- a/src/app/(marketing)/cohorts/page.tsx
+++ b/src/app/(marketing)/cohorts/page.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+
+const cohorts = [
+  { slug: 'forge-cohort-01', name: 'Forge Cohort 01', status: 'Completed', dates: 'Jan–Apr 2026' },
+  { slug: 'forge-cohort-02', name: 'Forge Cohort 02', status: 'Live', dates: 'May–Aug 2026' },
+];
+
+export default function CohortsPage() {
+  return (
+    <div className="container mx-auto max-w-7xl space-y-8 px-4 py-14 md:px-6 md:py-20">
+      <header className="max-w-3xl space-y-3">
+        <h1 className="text-4xl font-semibold tracking-tight">Cohorts</h1>
+        <p className="text-muted-foreground">A public archive of every Webara Forge cohort with teams, members, projects, and outcomes.</p>
+      </header>
+      <div className="grid gap-4 md:grid-cols-2">
+        {cohorts.map((cohort) => (
+          <Link key={cohort.slug} href={`/cohorts/${cohort.slug}`} className="rounded-lg border border-border bg-card p-6">
+            <p className="text-xs uppercase tracking-[0.16em] text-primary">{cohort.status}</p>
+            <h2 className="mt-2 text-xl font-semibold">{cohort.name}</h2>
+            <p className="mt-1 text-sm text-muted-foreground">{cohort.dates}</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(marketing)/contact/page.tsx
+++ b/src/app/(marketing)/contact/page.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+
+const paths = ['Applications', 'Partnerships', 'Institutions', 'Companies', 'Media', 'Hackathon enquiries'];
+
+export default function ContactPage() {
+  return (
+    <div className="container mx-auto max-w-4xl space-y-8 px-4 py-14 md:px-6 md:py-20">
+      <h1 className="text-4xl font-semibold tracking-tight">Contact</h1>
+      <p className="text-muted-foreground">Use the structured enquiry flow to route your request to the right Webara Forge team.</p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {paths.map((path) => (
+          <div key={path} className="rounded-lg border border-border bg-card p-4 text-sm font-medium">
+            {path}
+          </div>
+        ))}
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Need immediate support? Reach us via{' '}
+        <Link href="mailto:hello@webaraforge.com" className="text-primary underline underline-offset-4">
+          hello@webaraforge.com
+        </Link>
+        .
+      </p>
+    </div>
+  );
+}

--- a/src/app/(marketing)/faq/page.tsx
+++ b/src/app/(marketing)/faq/page.tsx
@@ -1,0 +1,23 @@
+const faqs = [
+  'Who can apply to a cohort?',
+  'Do applicants need to be technical?',
+  'How does housing work?',
+  'Can companies recruit from the Forge?',
+  'What happens to projects after cohort completion?',
+];
+
+export default function FaqPage() {
+  return (
+    <div className="container mx-auto max-w-4xl space-y-8 px-4 py-14 md:px-6 md:py-20">
+      <h1 className="text-4xl font-semibold tracking-tight">FAQ</h1>
+      <div className="space-y-3">
+        {faqs.map((faq) => (
+          <article key={faq} className="rounded-lg border border-border bg-card p-6">
+            <h2 className="text-lg font-semibold">{faq}</h2>
+            <p className="mt-2 text-sm text-muted-foreground">Answer content is managed as FAQ items so updates can happen without code changes.</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(marketing)/for-companies/page.tsx
+++ b/src/app/(marketing)/for-companies/page.tsx
@@ -1,0 +1,16 @@
+import { ForgePage } from '@/components/sections/forge-page';
+
+export default function ForCompaniesPage() {
+  return (
+    <ForgePage
+      eyebrow="Companies"
+      title="Work with the Forge to solve real operating problems."
+      intro="SMEs, startups, and larger companies can submit problems, sponsor challenges, and recruit verified talent."
+      sections={[
+        { heading: 'Engagement paths', body: 'Submit a challenge, sponsor a sprint track, partner with a cohort, or recruit directly from the talent archive.' },
+        { heading: 'Value to companies', body: 'Get access to fast-moving teams and a disciplined execution framework that prioritizes measurable outcomes.' },
+      ]}
+      ctas={[{ href: '/contact', label: 'Submit a company problem' }]}
+    />
+  );
+}

--- a/src/app/(marketing)/for-institutions/page.tsx
+++ b/src/app/(marketing)/for-institutions/page.tsx
@@ -1,0 +1,16 @@
+import { ForgePage } from '@/components/sections/forge-page';
+
+export default function ForInstitutionsPage() {
+  return (
+    <ForgePage
+      eyebrow="Institutions"
+      title="Build a stronger venture talent pipeline with Webara Forge."
+      intro="Universities and technical institutes can partner on hackathons, referrals, and practical venture exposure pathways."
+      sections={[
+        { heading: 'Partnership models', body: 'Co-host events, refer high-potential students, and align practical startup pathways with curriculum outcomes.' },
+        { heading: 'Collaboration outcomes', body: 'Institutions gain a visible bridge from student talent to venture execution and employment pathways.' },
+      ]}
+      ctas={[{ href: '/contact', label: 'Partner as institution' }]}
+    />
+  );
+}

--- a/src/app/(marketing)/hackathon/page.tsx
+++ b/src/app/(marketing)/hackathon/page.tsx
@@ -1,0 +1,16 @@
+import { ForgePage } from '@/components/sections/forge-page';
+
+export default function HackathonPage() {
+  return (
+    <ForgePage
+      eyebrow="Hackathon"
+      title="National discovery engine for the next generation of builders."
+      intro="The Webara Forge Hackathon identifies high-potential talent and channels top teams into long-term build environments."
+      sections={[
+        { heading: 'Who can enter', body: 'Students, early-career professionals, and independent builders across Ghana with real problem-solving ability.' },
+        { heading: 'Why it matters', body: 'The hackathon bridges institutions, sponsors, and startup pathways into one transparent pipeline.' },
+      ]}
+      ctas={[{ href: '/contact', label: 'Sponsor the hackathon' }, { href: '/faq', label: 'Hackathon FAQ', variant: 'outline' }]}
+    />
+  );
+}

--- a/src/app/(marketing)/hire-from-the-forge/page.tsx
+++ b/src/app/(marketing)/hire-from-the-forge/page.tsx
@@ -1,0 +1,16 @@
+import { ForgePage } from '@/components/sections/forge-page';
+
+export default function HireFromForgePage() {
+  return (
+    <ForgePage
+      eyebrow="Hiring"
+      title="Hire operators trained in real startup pressure."
+      intro="Companies can recruit product, engineering, and commercial talent with documented project execution history."
+      sections={[
+        { heading: 'Why Forge talent', body: 'Members are assessed through shipped products, sprint accountability, and customer validation work.' },
+        { heading: 'How hiring works', body: 'Submit your role needs, review member profiles, and connect directly with shortlisted candidates.' },
+      ]}
+      ctas={[{ href: '/contact', label: 'Hire from the Forge' }, { href: '/members', label: 'Browse members', variant: 'outline' }]}
+    />
+  );
+}

--- a/src/app/(marketing)/how-it-works/page.tsx
+++ b/src/app/(marketing)/how-it-works/page.tsx
@@ -1,0 +1,27 @@
+import { ForgePage } from '@/components/sections/forge-page';
+
+export default function HowItWorksPage() {
+  return (
+    <ForgePage
+      eyebrow="Model"
+      title="A 14-week system for building under pressure."
+      intro="Each cohort follows a clear operating cadence from orientation to demo week, with evidence-based continuation decisions."
+      sections={[
+        {
+          heading: 'Cohort sequence',
+          body: 'Week 1 orientation, Validation Round 1, Sprint 1, Validation Round 2, Sprint 2, and Demo Week.',
+        },
+        {
+          heading: 'Team composition',
+          body: 'Teams typically include product, technical, and commercial operators to keep execution balanced.',
+          bullets: ['Product / PM', 'Engineering', 'Sales or growth operator'],
+        },
+        {
+          heading: 'Continue / Park / Kill',
+          body: 'Projects are assessed frequently and routed based on traction evidence, not sentiment.',
+        },
+      ]}
+      ctas={[{ href: '/cohorts', label: 'View cohorts' }, { href: '/projects', label: 'Explore outputs', variant: 'outline' }]}
+    />
+  );
+}

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,62 +1,33 @@
-// src/app/(marketing)/layout.tsx
 import type { Metadata } from 'next';
 import React from 'react';
 
-const siteUrl = 'https://webarastudio.com';
+import { Footer } from '@/components/layout/footer';
+import { MarketingHeader } from '@/components/layout/marketing-header';
+
+const siteUrl = 'https://webaraforge.com';
 
 const websiteJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'WebSite',
-  name: 'Webara Studio',
+  name: 'Webara Forge',
   url: siteUrl,
-};
-
-const faqJsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'FAQPage',
-  mainEntity: [
-    {
-      '@type': 'Question',
-      name: 'How does the profit-share pricing work?',
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: 'You choose how much new digital revenue to share with Webara in exchange for discounts on build costs—up to fully funded projects when partnership depth increases.',
-      },
-    },
-    {
-      '@type': 'Question',
-      name: 'Do you build SaaS and B2B products as well as marketing sites?',
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: 'Yes. We design and ship SaaS, B2B platforms, and high-converting marketing sites, including AI automations for bookings, support, and ops.',
-      },
-    },
-    {
-      '@type': 'Question',
-      name: 'How fast can we launch?',
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: 'Most MVPs and marketing sites launch within weeks. Timelines depend on scope, but we prioritize fast, collaborative delivery with transparent retainers.',
-      },
-    },
-  ],
 };
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
   title: {
-    default: 'Webara Studio | SaaS & B2B Product Partner',
-    template: '%s | Webara Studio',
+    default: 'Webara Forge | Startups are forged here',
+    template: '%s | Webara Forge',
   },
   description:
-    'Webara Studio co-builds SaaS and B2B products with transparent retainers, shared IP, and enterprise delivery—launch faster with a partner who ships.',
+    'Webara Forge is a selective hacker house and venture studio in Tema, Ghana. Build, validate, and ship in a high-pressure 14-week model.',
   alternates: {
     canonical: siteUrl,
   },
   openGraph: {
-    title: 'Webara Studio | SaaS & B2B Product Partner',
+    title: 'Webara Forge | Startups are forged here',
     description:
-      'Co-create modern, performant web apps and marketing sites. Transparent retainers, shared IP, and results-focused builds.',
+      'A selective hacker house and venture studio documenting cohorts, members, projects, and measurable proof of work.',
     url: siteUrl,
     type: 'website',
     images: [
@@ -64,31 +35,25 @@ export const metadata: Metadata = {
         url: '/webarabadge.webp',
         width: 1200,
         height: 630,
-        alt: 'Webara Studio — SaaS & B2B Product Partner',
+        alt: 'Webara Forge',
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Webara Studio | SaaS & B2B Product Partner',
+    title: 'Webara Forge | Startups are forged here',
     description:
-      'Webara Studio builds high-converting, performant web experiences in partnership with your team.',
+      'Selective 14-week venture studio cohorts in Tema, Ghana. Build under pressure and show proof of output.',
     images: ['/webarabadge.webp'],
   },
 };
 
 function StructuredData() {
   return (
-    <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-    </>
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+    />
   );
 }
 
@@ -98,9 +63,11 @@ export default function MarketingLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
+    <div className="page-shell">
       <StructuredData />
-      {children}
-    </>
+      <MarketingHeader />
+      <main className="page-main">{children}</main>
+      <Footer />
+    </div>
   );
 }

--- a/src/app/(marketing)/media/[slug]/page.tsx
+++ b/src/app/(marketing)/media/[slug]/page.tsx
@@ -1,0 +1,12 @@
+export default async function MediaDetailPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+
+  return (
+    <div className="container mx-auto max-w-7xl space-y-8 px-4 py-14 md:px-6 md:py-20">
+      <h1 className="text-4xl font-semibold tracking-tight">{slug.replaceAll('-', ' ')}</h1>
+      <p className="max-w-3xl text-muted-foreground">
+        Each media page supports embedded video, article copy, linked projects, and related cohort records.
+      </p>
+    </div>
+  );
+}

--- a/src/app/(marketing)/media/page.tsx
+++ b/src/app/(marketing)/media/page.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+
+const stories = [
+  { slug: 'inside-the-forge-week-3', type: 'Build Diary' },
+  { slug: 'cohort-01-demo-recap', type: 'Cohort Recap' },
+  { slug: 'partner-interview-ecosystem', type: 'Interview' },
+];
+
+export default function MediaPage() {
+  return (
+    <div className="container mx-auto max-w-7xl space-y-8 px-4 py-14 md:px-6 md:py-20">
+      <header className="max-w-3xl space-y-3">
+        <h1 className="text-4xl font-semibold tracking-tight">Media · Inside the Forge</h1>
+        <p className="text-muted-foreground">Interviews, explainers, diaries, and recaps that make execution visible.</p>
+      </header>
+      <div className="grid gap-4 md:grid-cols-3">
+        {stories.map((story) => (
+          <Link key={story.slug} href={`/media/${story.slug}`} className="rounded-lg border border-border bg-card p-6">
+            <p className="text-xs uppercase tracking-[0.16em] text-primary">{story.type}</p>
+            <h2 className="mt-2 text-xl font-semibold">{story.slug.replaceAll('-', ' ')}</h2>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(marketing)/members/[slug]/page.tsx
+++ b/src/app/(marketing)/members/[slug]/page.tsx
@@ -1,0 +1,12 @@
+export default async function MemberProfilePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+
+  return (
+    <div className="container mx-auto max-w-7xl space-y-8 px-4 py-14 md:px-6 md:py-20">
+      <h1 className="text-4xl font-semibold tracking-tight">{slug.replaceAll('-', ' ')}</h1>
+      <p className="max-w-3xl text-muted-foreground">
+        Member profile pages combine biography, strengths, cohort participation, project contributions, and social/GitHub links.
+      </p>
+    </div>
+  );
+}

--- a/src/app/(marketing)/members/page.tsx
+++ b/src/app/(marketing)/members/page.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+
+const members = [
+  { slug: 'ama-boateng', name: 'Ama Boateng', role: 'Product Operator' },
+  { slug: 'kwesi-mensah', name: 'Kwesi Mensah', role: 'Founding Engineer' },
+  { slug: 'nana-adjei', name: 'Nana Adjei', role: 'Sales Builder' },
+];
+
+export default function MembersPage() {
+  return (
+    <div className="container mx-auto max-w-7xl space-y-8 px-4 py-14 md:px-6 md:py-20">
+      <header className="max-w-3xl space-y-3">
+        <h1 className="text-4xl font-semibold tracking-tight">Members</h1>
+        <p className="text-muted-foreground">Profile archive that demonstrates talent density across cohorts and operating roles.</p>
+      </header>
+      <div className="grid gap-4 md:grid-cols-3">
+        {members.map((member) => (
+          <Link key={member.slug} href={`/members/${member.slug}`} className="rounded-lg border border-border bg-card p-6">
+            <h2 className="text-xl font-semibold">{member.name}</h2>
+            <p className="mt-2 text-sm text-muted-foreground">{member.role}</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,106 +1,65 @@
-'use client';
+import Link from 'next/link';
 
-// src/app/page.tsx
-import { MarketingHeader } from '@/components/layout/marketing-header';
-import dynamic from 'next/dynamic';
-import { HeroSection } from '@/components/sections/hero-section';
-import { HowItWorksSection } from '@/components/sections/how-it-works-section';
-import { PortfolioSection } from '@/components/sections/portfolio-section';
-import { AboutSection } from '@/components/sections/about-section';
-import { Footer } from '@/components/layout/footer';
-import { useAnimation } from '@/contexts/animation-context';
+import { Button } from '@/components/ui/button';
+import { ctaLinks } from '@/lib/forge-content';
 
-const TestimonialsSection = dynamic(
-  () =>
-    import('@/components/sections/testimonials-section').then(
-      (mod) => mod.TestimonialsSection
-    ),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
-        Loading testimonials…
-      </div>
-    ),
-  }
-);
-
-const QuoteSection = dynamic(
-  () =>
-    import('@/components/sections/quote-section').then(
-      (mod) => mod.QuoteSection
-    ),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
-        Loading quote form…
-      </div>
-    ),
-  }
-);
-
-const IntroAnimation = dynamic(
-  () =>
-    import('@/components/intro-animation').then((mod) => mod.IntroAnimation),
-  { ssr: false }
-);
-
-// NOTE: metadata export removed because this is now a client component.
-// Move SEO metadata into a server layout (e.g. src/app/(marketing)/layout.tsx) instead.
-
-// JSON-LD Organization schema for enhanced rich results
-const organizationJsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'Organization',
-  name: 'Webara Studio',
-  url: 'https://webarastudio.com',
-  logo: 'https://webarastudio.com/webaralogo.webp',
-  contactPoint: [
-    {
-      '@type': 'ContactPoint',
-      contactType: 'customer support',
-      email: 'info@webarastudio.com',
-      availableLanguage: ['en'],
-    },
-  ],
-};
+const highlights = [
+  '14-week live-in cohort model with validation rounds, sprint cycles, and demo week.',
+  'Selective admissions designed for ambitious builders, operators, and founders.',
+  'Public proof-of-work archive across cohorts, projects, members, and media.',
+];
 
 export default function Home() {
-  const { isAnimationVisible } = useAnimation();
   return (
     <>
-      {/* Organization JSON-LD for rich results */}
-      <script
-        type="application/ld+json"
-        suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
-      />
-      {isAnimationVisible && <IntroAnimation />}
-      <div className="page-shell">
-        <MarketingHeader />
-        <main className="page-main">
-          <section className="section-px">
-            <HeroSection />
-          </section>
-          <section className="section-px">
-            <HowItWorksSection />
-          </section>
-          <section className="section-px" id="portfolio">
-            <PortfolioSection />
-          </section>
-          <section className="section-px">
-            <AboutSection />
-          </section>
-          <section className="section-px">
-            <TestimonialsSection />
-          </section>
-          <section className="section-px" id="contact">
-            <QuoteSection />
-          </section>
-        </main>
-        <Footer />
-      </div>
+        <section className="border-b border-border">
+          <div className="container mx-auto max-w-7xl space-y-8 px-4 py-20 md:px-6 md:py-28">
+            <p className="text-xs font-semibold uppercase tracking-[0.25em] text-primary">
+              Webara Forge · Tema, Ghana
+            </p>
+            <h1 className="max-w-4xl text-5xl font-bold tracking-tight md:text-6xl">
+              Startups are forged here.
+            </h1>
+            <p className="max-w-3xl text-lg leading-8 text-muted-foreground">
+              A selective hacker house and venture studio where small teams build
+              under pressure, validate quickly, and turn signal into enduring
+              companies.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Button asChild size="lg">
+                <Link href="/apply">Apply</Link>
+              </Button>
+              <Button asChild size="lg" variant="outline">
+                <Link href="/projects">Explore Projects</Link>
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        <section className="container mx-auto max-w-7xl px-4 py-16 md:px-6">
+          <div className="grid gap-4 md:grid-cols-3">
+            {highlights.map((item) => (
+              <article key={item} className="rounded-lg border border-border bg-card p-6 text-sm leading-6 text-foreground/90">
+                {item}
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="container mx-auto max-w-7xl space-y-6 px-4 pb-20 md:px-6">
+          <h2 className="text-2xl font-semibold">Key journeys</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            {ctaLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="rounded-lg border border-border bg-card p-6 text-lg font-medium transition-colors hover:border-primary hover:text-primary"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </section>
     </>
   );
 }

--- a/src/app/(marketing)/partners/page.tsx
+++ b/src/app/(marketing)/partners/page.tsx
@@ -1,0 +1,16 @@
+import { ForgePage } from '@/components/sections/forge-page';
+
+export default function PartnersPage() {
+  return (
+    <ForgePage
+      eyebrow="Partners"
+      title="A structured partnership layer for execution-minded institutions."
+      intro="Webara Forge collaborates with academic, ecosystem, challenge, technical, media, and hiring partners."
+      sections={[
+        { heading: 'Partnership categories', body: 'Academic partners, hiring partners, technical platforms, challenge sponsors, and ecosystem operators each have clear engagement paths.' },
+        { heading: 'Ways to engage', body: 'Submit problems, sponsor cohort challenges, support hackathons, or recruit directly from member profiles.' },
+      ]}
+      ctas={[{ href: '/contact', label: 'Partner with Webara Forge' }, { href: '/hire-from-the-forge', label: 'Hire from the Forge', variant: 'outline' }]}
+    />
+  );
+}

--- a/src/app/(marketing)/projects/[slug]/page.tsx
+++ b/src/app/(marketing)/projects/[slug]/page.tsx
@@ -1,0 +1,20 @@
+export default async function ProjectDetailPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+
+  return (
+    <div className="container mx-auto max-w-7xl space-y-8 px-4 py-14 md:px-6 md:py-20">
+      <h1 className="text-4xl font-semibold tracking-tight">{slug.replaceAll('-', ' ')}</h1>
+      <p className="max-w-3xl text-muted-foreground">
+        This project page captures the problem, team, build milestones, validation evidence, repository links, and next disposition.
+      </p>
+      <div className="grid gap-4 md:grid-cols-2">
+        {['Problem and target users', 'What was built', 'Traction signal', 'Next step'].map((label) => (
+          <article key={label} className="rounded-lg border border-border bg-card p-6">
+            <h2 className="text-lg font-semibold">{label}</h2>
+            <p className="mt-2 text-sm text-muted-foreground">CMS-backed content placeholder for launch-phase samples and later archived cohorts.</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(marketing)/projects/page.tsx
+++ b/src/app/(marketing)/projects/page.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+
+const projects = [
+  { slug: 'signal-ledger', name: 'Signal Ledger', status: 'Live', cohort: 'Cohort 02' },
+  { slug: 'market-route', name: 'Market Route', status: 'Continued', cohort: 'Cohort 01' },
+  { slug: 'pilot-grid', name: 'Pilot Grid', status: 'Archived', cohort: 'Cohort 01' },
+];
+
+export default function ProjectsPage() {
+  return (
+    <div className="container mx-auto max-w-7xl space-y-8 px-4 py-14 md:px-6 md:py-20">
+      <header className="max-w-3xl space-y-3">
+        <h1 className="text-4xl font-semibold tracking-tight">Projects</h1>
+        <p className="text-muted-foreground">Filterable archive of products built through the Forge with status, cohort, and execution evidence.</p>
+      </header>
+      <div className="grid gap-4 md:grid-cols-3">
+        {projects.map((project) => (
+          <Link key={project.slug} href={`/projects/${project.slug}`} className="rounded-lg border border-border bg-card p-6">
+            <p className="text-xs uppercase tracking-[0.16em] text-primary">{project.status}</p>
+            <h2 className="mt-2 text-xl font-semibold">{project.name}</h2>
+            <p className="mt-1 text-sm text-muted-foreground">{project.cohort}</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(marketing)/teams/[slug]/page.tsx
+++ b/src/app/(marketing)/teams/[slug]/page.tsx
@@ -1,0 +1,12 @@
+export default async function TeamDetailPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+
+  return (
+    <div className="container mx-auto max-w-7xl space-y-8 px-4 py-14 md:px-6 md:py-20">
+      <h1 className="text-4xl font-semibold tracking-tight">Team: {slug.replaceAll('-', ' ')}</h1>
+      <p className="max-w-3xl text-muted-foreground">
+        Team pages document member composition, project sequence, sprint output, and validation outcomes within each cohort.
+      </p>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,57 +4,58 @@
 
 @layer base {
   :root {
-    --background: 200 25% 15%;
-    --foreground: 40 30% 85%;
-    --card: 200 25% 18%;
-    --card-foreground: 40 30% 85%;
-    --popover: 200 25% 12%;
-    --popover-foreground: 40 30% 85%;
-    --primary: 40 70% 60%;
-    --primary-foreground: 200 25% 10%;
-    --secondary: 200 15% 25%;
-    --secondary-foreground: 40 30% 85%;
-    --muted: 200 15% 25%;
-    --muted-foreground: 40 30% 75%;
-    --accent: 15 70% 50%;
+    --background: 0 0% 4%;
+    --foreground: 38 24% 88%;
+    --card: 0 0% 16%;
+    --card-foreground: 38 24% 88%;
+    --popover: 0 0% 10%;
+    --popover-foreground: 38 24% 88%;
+    --primary: 38 50% 57%;
+    --primary-foreground: 0 0% 4%;
+    --secondary: 0 0% 16%;
+    --secondary-foreground: 38 24% 88%;
+    --muted: 0 0% 16%;
+    --muted-foreground: 38 12% 76%;
+    --accent: 11 62% 48%;
     --accent-foreground: 0 0% 100%;
     --destructive: 0 63% 31%;
     --destructive-foreground: 0 0% 98%;
-    --border: 200 15% 30%;
-    --input: 200 15% 30%;
-    --ring: 40 70% 60%;
-    --chart-1: 40 70% 60%;
-    --chart-2: 15 70% 50%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
+    --border: 0 0% 20%;
+    --input: 0 0% 20%;
+    --ring: 38 50% 57%;
+    --chart-1: 38 50% 57%;
+    --chart-2: 11 62% 48%;
+    --chart-3: 0 0% 25%;
+    --chart-4: 38 24% 88%;
+    --chart-5: 0 0% 32%;
     --radius: 0.5rem;
   }
+
   .dark {
-    --background: 200 25% 15%;
-    --foreground: 40 30% 85%;
-    --card: 200 25% 18%;
-    --card-foreground: 40 30% 85%;
-    --popover: 200 25% 12%;
-    --popover-foreground: 40 30% 85%;
-    --primary: 40 70% 60%;
-    --primary-foreground: 200 25% 10%;
-    --secondary: 200 15% 25%;
-    --secondary-foreground: 40 30% 85%;
-    --muted: 200 15% 25%;
-    --muted-foreground: 40 30% 75%;
-    --accent: 15 70% 50%;
+    --background: 0 0% 4%;
+    --foreground: 38 24% 88%;
+    --card: 0 0% 16%;
+    --card-foreground: 38 24% 88%;
+    --popover: 0 0% 10%;
+    --popover-foreground: 38 24% 88%;
+    --primary: 38 50% 57%;
+    --primary-foreground: 0 0% 4%;
+    --secondary: 0 0% 16%;
+    --secondary-foreground: 38 24% 88%;
+    --muted: 0 0% 16%;
+    --muted-foreground: 38 12% 76%;
+    --accent: 11 62% 48%;
     --accent-foreground: 0 0% 100%;
     --destructive: 0 63% 31%;
     --destructive-foreground: 0 0% 98%;
-    --border: 200 15% 30%;
-    --input: 200 15% 30%;
-    --ring: 40 70% 60%;
-    --chart-1: 40 70% 60%;
-    --chart-2: 15 70% 50%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
+    --border: 0 0% 20%;
+    --input: 0 0% 20%;
+    --ring: 38 50% 57%;
+    --chart-1: 38 50% 57%;
+    --chart-2: 11 62% 48%;
+    --chart-3: 0 0% 25%;
+    --chart-4: 38 24% 88%;
+    --chart-5: 0 0% 32%;
   }
 }
 
@@ -67,7 +68,6 @@
     font-family: var(--font-body), system-ui, -apple-system, sans-serif;
   }
 
-  /* Improve mobile scrolling + safe area */
   html,
   body {
     min-height: 100%;
@@ -85,52 +85,46 @@
   }
 
   .page-main {
-    @apply flex-1 w-full;
+    @apply w-full flex-1;
   }
 
   .page-main-centered {
-    @apply flex-1 flex items-center justify-center px-4 py-6 sm:px-6;
+    @apply flex flex-1 items-center justify-center px-4 py-6 sm:px-6;
   }
 
   .page-card-auth {
-    @apply w-full max-w-sm mx-auto;
+    @apply mx-auto w-full max-w-sm;
   }
 
-  /* Ensures cards and grids don’t overflow on small screens */
   .responsive-card {
     @apply w-full max-w-full overflow-hidden;
   }
 
   .responsive-grid-2-4 {
-    @apply grid gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4;
+    @apply grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4;
   }
 
   .responsive-grid-1-3 {
-    @apply grid gap-6 grid-cols-1 lg:grid-cols-3;
+    @apply grid grid-cols-1 gap-6 lg:grid-cols-3;
   }
 
-  /* Tables: horizontal scroll on narrow viewports */
   .table-scroll-x {
     @apply w-full overflow-x-auto;
   }
 
-  /* Dialogs & sheets: full width on mobile, constrained on desktop */
   .dialog-responsive {
-    @apply w-full max-w-full sm:max-w-xl lg:max-w-4xl max-h-[90vh] p-4 sm:p-6 md:p-8;
+    @apply max-h-[90vh] w-full max-w-full p-4 sm:max-w-xl sm:p-6 md:p-8 lg:max-w-4xl;
   }
 
   .sheet-responsive {
     @apply w-[85vw] max-w-sm;
   }
 
-  /* Utility to prevent text from hitting edges on small screens */
   .section-px {
     @apply px-4 sm:px-6;
   }
-}
 
-@layer components {
   .carousel-nav-button {
-      @apply bg-background/50 border-border text-foreground/50 hover:bg-background hover:text-foreground hover:border-primary;
+    @apply border-border bg-background/50 text-foreground/50 hover:border-primary hover:bg-background hover:text-foreground;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,66 +1,57 @@
-// src/app/layout.tsx
 import type { Metadata } from 'next';
-import './globals.css';
+
 import { Toaster } from '@/components/ui/toaster';
-import { Poppins } from 'next/font/google';
+
+import './globals.css';
 import { ClientProviders } from './providers-client';
 
-const poppins = Poppins({
-  subsets: ['latin'],
-  weight: ['300', '400', '500', '600', '700', '800', '900'],
-  display: 'swap',
-  variable: '--font-body',
-});
-
 export const metadata: Metadata = {
-  metadataBase: new URL('https://webarastudio.com'),
+  metadataBase: new URL('https://webaraforge.com'),
   title: {
-    default: 'Webara Studio | SaaS & B2B Product Partner',
-    template: '%s | Webara Studio',
+    default: 'Webara Forge | Startups are forged here',
+    template: '%s | Webara Forge',
   },
   description:
-    'Webara Studio co-builds SaaS and B2B products with transparent retainers, shared IP, and enterprise delivery—launch faster with a partner who ships.',
+    'Webara Forge is a selective hacker house and venture studio in Tema, Ghana. Build, validate, and ship in a high-pressure 14-week model.',
   alternates: {
-    canonical: 'https://webarastudio.com',
+    canonical: 'https://webaraforge.com',
   },
   robots: {
     index: true,
     follow: true,
   },
   keywords: [
-    'Webara Studio',
-    'web development agency',
-    'SaaS product design',
-    'Next.js experts',
-    'React development',
-    'B2B landing pages',
-    'startup product studio',
-    'collaborative product development',
+    'Webara Forge',
+    'hacker house Ghana',
+    'venture studio Ghana',
+    'startup accelerator Tema',
+    'startup talent Ghana',
+    'hackathon Ghana',
   ],
-  authors: [{ name: 'Webara Studio', url: 'https://webarastudio.com' }],
-  creator: 'Webara Studio',
-  publisher: 'Webara Studio',
+  authors: [{ name: 'Webara Forge', url: 'https://webaraforge.com' }],
+  creator: 'Webara Forge',
+  publisher: 'Webara Forge',
   openGraph: {
     type: 'website',
-    url: 'https://webarastudio.com',
-    title: 'Webara Studio | SaaS & B2B Product Partner',
+    url: 'https://webaraforge.com',
+    title: 'Webara Forge | Startups are forged here',
     description:
-      'Co-create modern, performant web apps and marketing sites. Transparent retainers, shared IP, and results-focused builds.',
-    siteName: 'Webara Studio',
+      'A selective hacker house and venture studio documenting cohorts, projects, members, and proof of output.',
+    siteName: 'Webara Forge',
     images: [
       {
         url: '/webarabadge.webp',
         width: 1200,
         height: 630,
-        alt: 'Webara Studio - Collaborative Digital Product Studio',
+        alt: 'Webara Forge',
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Webara Studio | SaaS & B2B Product Partner',
+    title: 'Webara Forge | Startups are forged here',
     description:
-      'Webara Studio builds high-converting, performant web experiences in partnership with your team.',
+      'Selective 14-week venture studio cohorts in Tema, Ghana. Build under pressure and show proof of output.',
     images: ['/webarabadge.webp'],
   },
   icons: {
@@ -88,9 +79,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`!scroll-smooth ${poppins.variable}`}>
+    <html lang="en" className="!scroll-smooth">
       <head />
-      <body className={`font-body antialiased ${poppins.className}`}>
+      <body className="font-body antialiased">
         <ClientProviders>{children}</ClientProviders>
         <Toaster />
       </body>

--- a/src/app/providers-client.tsx
+++ b/src/app/providers-client.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import type { PropsWithChildren } from 'react';
-import { AppProviders } from './providers';
+
 import { PwaInit } from '@/components/pwa-init';
+
+import { AppProviders } from './providers';
 
 export function ClientProviders({ children }: PropsWithChildren) {
   return (

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,41 +1,39 @@
 import type { MetadataRoute } from 'next';
-import { blogPosts } from '@/lib/blog-posts';
 
-const BASE_URL = 'https://webarastudio.com';
+const BASE_URL = 'https://webaraforge.com';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticRoutes: string[] = [
     '',
-    '/blog',
-    '/services',
-    '/case-studies',
-    '/pricing',
+    '/about',
+    '/how-it-works',
+    '/cohorts',
+    '/projects',
+    '/members',
+    '/partners',
+    '/hackathon',
+    '/media',
+    '/apply',
+    '/hire-from-the-forge',
+    '/for-institutions',
+    '/for-companies',
+    '/faq',
+    '/contact',
     '/privacy-policy',
     '/terms-of-service',
-    '/login',
-    '/signup',
   ];
 
-  const staticEntries = staticRoutes.map((route) => ({
+  return staticRoutes.map((route) => ({
     url: `${BASE_URL}${route}`,
     lastModified: new Date().toISOString(),
-    changeFrequency: 'weekly' as const,
+    changeFrequency: route === '' || route === '/cohorts' || route === '/projects' ? 'weekly' : 'monthly',
     priority:
       route === ''
         ? 1.0
-        : route === '/blog'
-        ? 0.8
-        : route === '/privacy-policy' || route === '/terms-of-service'
-        ? 0.3
-        : 0.6,
+        : route === '/apply'
+          ? 0.9
+          : route === '/privacy-policy' || route === '/terms-of-service'
+            ? 0.3
+            : 0.7,
   }));
-
-  const blogEntries = blogPosts.map((post) => ({
-    url: `${BASE_URL}/blog/${post.slug}`,
-    lastModified: new Date(post.date).toISOString(),
-    changeFrequency: 'monthly' as const,
-    priority: 0.7,
-  }));
-
-  return [...staticEntries, ...blogEntries];
 }

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,33 +1,36 @@
+import Link from 'next/link';
 
 import { Logo } from '@/components/logo';
-import Link from 'next/link';
+import { utilityNav } from '@/lib/forge-content';
 
 export function Footer() {
   return (
-    <footer className="bg-card border-t">
-      <div className="container mx-auto max-w-7xl px-4 md:px-6 py-8">
-        <div className="flex flex-col md:flex-row items-center justify-between gap-4">
+    <footer className="border-t border-border bg-card">
+      <div className="container mx-auto flex max-w-7xl flex-col gap-8 px-4 py-10 md:px-6">
+        <div className="flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
           <Logo />
-          <p className="text-sm text-foreground/70 text-center md:text-left">
-            © {new Date().getFullYear()} Webara Studio. All rights reserved.
+          <p className="max-w-xl text-sm text-muted-foreground">
+            Webara Forge is a selective hacker house and venture studio in Tema,
+            Ghana. Startups are forged here.
           </p>
-          <div className="flex gap-4">
-            <Link
-              href="/privacy-policy"
-              className="text-sm text-foreground/70 hover:text-foreground"
-              prefetch={false}
-            >
-              Privacy Policy
-            </Link>
-            <Link
-              href="/terms-of-service"
-              className="text-sm text-foreground/70 hover:text-foreground"
-              prefetch={false}
-            >
-              Terms of Service
-            </Link>
-          </div>
         </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+          {utilityNav.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="text-sm text-foreground/75 transition-colors hover:text-primary"
+              prefetch={false}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          © {new Date().getFullYear()} Webara Forge. All rights reserved.
+        </p>
       </div>
     </footer>
   );

--- a/src/components/layout/marketing-header.tsx
+++ b/src/components/layout/marketing-header.tsx
@@ -1,10 +1,10 @@
-"use client";
+'use client';
 
-import React from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { Button } from '@/components/ui/button';
+import { Menu } from 'lucide-react';
+
 import { Logo } from '@/components/logo';
+import { Button } from '@/components/ui/button';
 import {
   Sheet,
   SheetContent,
@@ -13,119 +13,71 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
-import { Menu } from 'lucide-react';
+import { primaryNav } from '@/lib/forge-content';
 
 export function MarketingHeader() {
-  const [isOpen, setIsOpen] = React.useState(false);
-  const router = useRouter();
-
-  const navLinks = [
-    { href: '/#portfolio', label: 'Portfolio' },
-    { href: '/#about', label: 'About' },
-    { href: '/blog', label: 'Blog' },
-    { href: '/case-studies', label: 'Case Studies' },
-    { href: '/#contact', label: 'Get a Quote' },
-  ];
-
-  const handleNav = (
-    e: React.MouseEvent<HTMLAnchorElement>,
-    href: string
-  ) => {
-    if (href.startsWith('/#')) {
-        e.preventDefault();
-        const targetElement = document.querySelector(href.substring(1));
-        if (targetElement) {
-          targetElement.scrollIntoView({ behavior: 'smooth' });
-        } else {
-          router.push(href);
-        }
-        setIsOpen(false);
-    }
-  };
-
-  const handleScroll = (
-    e: React.MouseEvent<HTMLAnchorElement>,
-    href: string
-  ) => {
-    e.preventDefault();
-    if (href.startsWith('/#')) {
-        const targetElement = document.querySelector(href.substring(1));
-        if (targetElement) {
-          targetElement.scrollIntoView({ behavior: 'smooth' });
-        } else {
-          router.push(href);
-        }
-    } else {
-        router.push(href);
-    }
-    setIsOpen(false);
-  };
-
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <header className="sticky top-0 z-50 w-full border-b border-border bg-background/95 backdrop-blur">
       <div className="container flex h-16 max-w-7xl items-center justify-between">
         <Logo />
-        <nav className="hidden md:flex items-center gap-6">
-          {navLinks.map((link) => (
+        <nav className="hidden items-center gap-6 md:flex">
+          {primaryNav.map((link) => (
             <Link
               key={link.href}
               href={link.href}
-              onClick={(e) => handleNav(e, link.href)}
-              className="relative text-sm font-medium text-foreground/70 transition-colors hover:text-foreground after:content-[''] after:absolute after:left-1/2 after:bottom-[-2px] after:h-[1.5px] after:w-0 after:bg-primary after:transition-all after:duration-300 after:-translate-x-1/2 hover:after:w-full"
+              className="text-sm font-medium text-foreground/80 transition-colors hover:text-primary"
               prefetch={false}
             >
               {link.label}
             </Link>
           ))}
         </nav>
-        <div className="hidden md:flex items-center gap-3">
+        <div className="hidden items-center gap-3 md:flex">
           <Button asChild size="sm" variant="outline">
-            <Link href="/login">Login</Link>
+            <Link href="/contact">Partner</Link>
           </Button>
           <Button asChild size="sm">
-            <Link href="/signup">Sign Up</Link>
+            <Link href="/apply">Apply</Link>
           </Button>
         </div>
-        <div className="md:hidden">
-          <Sheet open={isOpen} onOpenChange={setIsOpen}>
-            <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
-                <span className="sr-only">Toggle navigation menu</span>
-              </Button>
-            </SheetTrigger>
-            <SheetContent side="right">
-              <SheetHeader className="sr-only">
-                <SheetTitle>Mobile navigation menu</SheetTitle>
-                <SheetDescription>Select a destination to navigate</SheetDescription>
-              </SheetHeader>
-              <div className="flex flex-col gap-6 p-6">
-                <Logo />
-                <nav className="flex flex-col gap-4">
-                  {navLinks.map((link) => (
-                    <Link
-                      key={link.href}
-                      href={link.href}
-                      onClick={(e) => handleScroll(e, link.href)}
-                      className="text-lg font-medium text-foreground/80 transition-colors hover:text-foreground"
-                      prefetch={false}
-                    >
-                      {link.label}
-                    </Link>
-                  ))}
-                </nav>
-                <div className="flex flex-col gap-2 pt-4 border-t">
-                  <Button asChild className="w-full" onClick={() => setIsOpen(false)}>
-                    <Link href="/login">Login</Link>
-                  </Button>
-                  <Button asChild variant="outline" className="w-full" onClick={() => setIsOpen(false)}>
-                    <Link href="/signup">Sign Up</Link>
-                  </Button>
-                </div>
+
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant="ghost" size="icon" className="md:hidden">
+              <Menu className="h-5 w-5" />
+              <span className="sr-only">Toggle navigation menu</span>
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="right" className="sheet-responsive">
+            <SheetHeader className="sr-only">
+              <SheetTitle>Navigation</SheetTitle>
+              <SheetDescription>Browse Webara Forge pages</SheetDescription>
+            </SheetHeader>
+            <div className="mt-6 flex flex-col gap-6">
+              <Logo />
+              <nav className="flex flex-col gap-4">
+                {primaryNav.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className="text-base font-medium text-foreground/85"
+                    prefetch={false}
+                  >
+                    {link.label}
+                  </Link>
+                ))}
+              </nav>
+              <div className="flex flex-col gap-2 border-t border-border pt-4">
+                <Button asChild>
+                  <Link href="/apply">Apply</Link>
+                </Button>
+                <Button asChild variant="outline">
+                  <Link href="/contact">Partner</Link>
+                </Button>
               </div>
-            </SheetContent>
-          </Sheet>
-        </div>
+            </div>
+          </SheetContent>
+        </Sheet>
       </div>
     </header>
   );

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -36,7 +36,7 @@ export function Logo({
     >
       <Image
         src={logoByVariant[variant]}
-        alt="Webara Studio"
+        alt="Webara Forge"
         width={160}
         height={42}
         sizes="160px"

--- a/src/components/sections/forge-page.tsx
+++ b/src/components/sections/forge-page.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link';
+
+import { Button } from '@/components/ui/button';
+
+type ForgePageProps = {
+  eyebrow?: string;
+  title: string;
+  intro: string;
+  sections: Array<{
+    heading: string;
+    body: string;
+    bullets?: string[];
+  }>;
+  ctas?: Array<{ href: string; label: string; variant?: 'default' | 'outline' }>;
+};
+
+export function ForgePage({
+  eyebrow,
+  title,
+  intro,
+  sections,
+  ctas = [],
+}: ForgePageProps) {
+  return (
+    <div className="container mx-auto max-w-7xl space-y-10 px-4 py-14 md:px-6 md:py-20">
+      <header className="max-w-3xl space-y-4">
+        {eyebrow ? (
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primary">
+            {eyebrow}
+          </p>
+        ) : null}
+        <h1 className="text-4xl font-semibold tracking-tight text-foreground md:text-5xl">
+          {title}
+        </h1>
+        <p className="text-base leading-7 text-muted-foreground md:text-lg">{intro}</p>
+      </header>
+
+      <section className="grid gap-6 md:grid-cols-2">
+        {sections.map((section) => (
+          <article key={section.heading} className="rounded-lg border border-border bg-card p-6">
+            <h2 className="text-xl font-semibold text-foreground">{section.heading}</h2>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">{section.body}</p>
+            {section.bullets?.length ? (
+              <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-foreground/85">
+                {section.bullets.map((bullet) => (
+                  <li key={bullet}>{bullet}</li>
+                ))}
+              </ul>
+            ) : null}
+          </article>
+        ))}
+      </section>
+
+      {ctas.length ? (
+        <div className="flex flex-wrap gap-3">
+          {ctas.map((cta) => (
+            <Button key={cta.href} asChild variant={cta.variant ?? 'default'}>
+              <Link href={cta.href}>{cta.label}</Link>
+            </Button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/contexts/auth-context-simple.tsx
+++ b/src/contexts/auth-context-simple.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
+
 import type { Database } from '@/lib/database.types';
 import { useSupabaseClient } from '@/lib/supabase/client';
 
@@ -37,7 +38,13 @@ interface SimpleAuthContextType extends SimpleAuthState {
   refreshProfile: () => Promise<void>;
 }
 
-const SimpleAuthContext = createContext<SimpleAuthContextType | undefined>(undefined);
+const SimpleAuthContext = createContext<SimpleAuthContextType | undefined>(
+  undefined
+);
+
+const missingSupabaseError = new Error(
+  'Authentication is not configured. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to enable auth.'
+);
 
 async function syncProfileWithSession(accessToken?: string | null, retries = 1) {
   const response = await fetch('/api/auth/profile-sync', {
@@ -56,7 +63,6 @@ async function syncProfileWithSession(accessToken?: string | null, retries = 1) 
     | null;
   const message = body?.error || 'Failed to sync profile.';
 
-  // Supabase SSR cookies can lag briefly behind the browser session after auth changes.
   if (retries > 0 && message === 'Unauthorized') {
     await new Promise((resolve) => setTimeout(resolve, 150));
     return syncProfileWithSession(accessToken, retries - 1);
@@ -81,6 +87,13 @@ export function SimpleAuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   const refreshProfile = useCallback(async () => {
+    if (!supabase) {
+      setUser(null);
+      setProfile(null);
+      setLoading(false);
+      return;
+    }
+
     const {
       data: { user: currentUser },
       error,
@@ -98,6 +111,11 @@ export function SimpleAuthProvider({ children }: { children: ReactNode }) {
   }, [session?.access_token, supabase]);
 
   useEffect(() => {
+    if (!supabase) {
+      setLoading(false);
+      return;
+    }
+
     let mounted = true;
 
     const initialize = async () => {
@@ -177,8 +195,7 @@ export function SimpleAuthProvider({ children }: { children: ReactNode }) {
     };
   }, [supabase]);
 
-  const isAdmin =
-    profile?.role === 'admin' || profile?.role === 'webara_staff';
+  const isAdmin = profile?.role === 'admin' || profile?.role === 'webara_staff';
 
   const value = useMemo<SimpleAuthContextType>(
     () => ({
@@ -189,7 +206,13 @@ export function SimpleAuthProvider({ children }: { children: ReactNode }) {
       isAdmin,
       signIn: async (email, password) => {
         if (!email || !password) {
-          return { error: new Error('Email and password are required.'), session: null };
+          return {
+            error: new Error('Email and password are required.'),
+            session: null,
+          };
+        }
+        if (!supabase) {
+          return { error: missingSupabaseError, session: null };
         }
 
         const { data, error } = await supabase.auth.signInWithPassword({
@@ -202,6 +225,9 @@ export function SimpleAuthProvider({ children }: { children: ReactNode }) {
       signUp: async (email, password, metadata) => {
         if (!email || !password) {
           return { error: new Error('Email and password are required.') };
+        }
+        if (!supabase) {
+          return { error: missingSupabaseError };
         }
 
         const { data, error } = await supabase.auth.signUp({
@@ -216,6 +242,13 @@ export function SimpleAuthProvider({ children }: { children: ReactNode }) {
         };
       },
       signOut: async () => {
+        if (!supabase) {
+          setUser(null);
+          setSession(null);
+          setProfile(null);
+          return;
+        }
+
         const { error } = await supabase.auth.signOut();
         if (error) {
           throw error;
@@ -230,9 +263,7 @@ export function SimpleAuthProvider({ children }: { children: ReactNode }) {
   );
 
   return (
-    <SimpleAuthContext.Provider value={value}>
-      {children}
-    </SimpleAuthContext.Provider>
+    <SimpleAuthContext.Provider value={value}>{children}</SimpleAuthContext.Provider>
   );
 }
 

--- a/src/lib/forge-content.ts
+++ b/src/lib/forge-content.ts
@@ -1,0 +1,25 @@
+export const primaryNav = [
+  { href: '/about', label: 'About' },
+  { href: '/how-it-works', label: 'How It Works' },
+  { href: '/cohorts', label: 'Cohorts' },
+  { href: '/projects', label: 'Projects' },
+  { href: '/members', label: 'Members' },
+  { href: '/partners', label: 'Partners' },
+  { href: '/hackathon', label: 'Hackathon' },
+  { href: '/media', label: 'Media' },
+];
+
+export const utilityNav = [
+  { href: '/hire-from-the-forge', label: 'Hire from the Forge' },
+  { href: '/for-institutions', label: 'For Institutions' },
+  { href: '/for-companies', label: 'For Companies' },
+  { href: '/faq', label: 'FAQ' },
+  { href: '/contact', label: 'Contact' },
+];
+
+export const ctaLinks = [
+  { href: '/apply', label: 'Apply' },
+  { href: '/partners', label: 'Partner with Webara Forge' },
+  { href: '/projects', label: 'Explore Projects' },
+  { href: '/hire-from-the-forge', label: 'Hire from the Forge' },
+];

--- a/src/lib/supabase/client.tsx
+++ b/src/lib/supabase/client.tsx
@@ -3,20 +3,19 @@
 import { useMemo } from 'react';
 import { createBrowserClient } from '@supabase/ssr';
 import type { SupabaseClient } from '@supabase/supabase-js';
+
 import type { Database } from '@/lib/database.types';
 
 let browserClient: SupabaseClient<Database> | null = null;
 
-export function createBrowserSupabaseClient() {
+export function createBrowserSupabaseClient(): SupabaseClient<Database> | null {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseKey =
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
   if (!supabaseUrl || !supabaseKey) {
-    throw new Error(
-      'Missing Supabase environment variables. Ensure NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are set.'
-    );
+    return null;
   }
 
   if (!browserClient) {
@@ -26,6 +25,6 @@ export function createBrowserSupabaseClient() {
   return browserClient;
 }
 
-export function useSupabaseClient(): SupabaseClient<Database> {
+export function useSupabaseClient(): SupabaseClient<Database> | null {
   return useMemo(() => createBrowserSupabaseClient(), []);
 }


### PR DESCRIPTION
### Motivation
- Rebrand the public marketing site from "Webara Studio" to "Webara Forge" and shift content toward a cohort-based venture studio product and talent archive.
- Provide a set of static marketing pages and shared components to document cohorts, projects, members, media, and partner journeys.
- Improve resilience around optional Supabase configuration so the app can run without auth environment variables during static builds or previews.

### Description
- Rebranded metadata, copy, and assets across `src/app/layout.tsx`, `src/app/(marketing)/layout.tsx`, `src/components/*` and other places to use "Webara Forge" and the new domain `https://webaraforge.com`.
- Added many marketing pages and route handlers under `src/app/(marketing)` including `about`, `apply`, `cohorts` (list + detail), `projects` (list + detail), `members` (list + detail), `media` (list + detail), `partners`, `hackathon`, `for-companies`, `for-institutions`, `hire-from-the-forge`, `how-it-works`, `faq`, and `contact` along with a reusable `ForgePage` section component in `src/components/sections/forge-page.tsx`.
- Updated header, footer, logo, and global navigation to use new nav data from `src/lib/forge-content.ts` and wired `ctaLinks` into the home page; simplified the marketing home page and removed some dynamic intro/testimonial loading.
- Adjusted styling and theme tokens in `src/app/globals.css` (color palette and utility ordering), and refined layout structure to include `MarketingHeader` and `Footer` wrappers.
- Made Supabase client and auth context more tolerant of missing env vars by returning `null` from `createBrowserSupabaseClient()` when keys are absent and guarding `SimpleAuthProvider` flows with clearer error messages, plus exported safer `useSupabaseClient()` signature.
- Simplified sitemap generation in `src/app/sitemap.ts` to reflect the new static routes for the Forge site and tuned `changeFrequency` and `priority` heuristics.

### Testing
- Ran a local type check with `npm run typecheck` and a full build with `next build`, both completed successfully.
- Ran `npm run lint` to validate formatting and common issues, which returned no errors.
- No automated unit tests were added or modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c82832f4288324bb63f33a3566d32a)